### PR TITLE
Fixed srvInfo.getDevelopers()

### DIFF
--- a/src/net/mcthunder/src/srvInfo.java
+++ b/src/net/mcthunder/src/srvInfo.java
@@ -1,6 +1,7 @@
 package net.mcthunder.src;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**


### PR DESCRIPTION
Fixed srvInfo.getDevelopers() to not add to the list every time it is called.
